### PR TITLE
possibility to use templated properties to apply by default on file update

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,42 @@ dbt-invoke properties.delete <options>
   - `<options>` uses the same arguments as for creating/updating property
     files, except for `--threads`.
 
+
+### Applying default properties using `dbt_invoke_template.yml`
+
+You can pass custom default properties to be added to property files on update.
+To do so, add a `dbt_invoke_template.yml` at the root of your dbt project,
+using the following convention:
+
+
+```
+model:
+  meta:
+    owner: "@default"
+  columns:
+    foo: "bar"
+
+seed:
+  meta:
+    owner: "@default"
+  columns:
+    foo: "bar"
+
+snapshot:
+  meta:
+    owner: "@default"
+  columns:
+    foo: "bar"
+
+analysis:
+  meta:
+    owner: "@default"
+  columns:
+    foo: "bar"
+```
+
+Note: only `model`, `seed`, `snapshot` and `analysis` are supported.
+
 ### Help
 
 - To view the list of available commands and their short descriptions, run:

--- a/dbt_invoke/internal/_utils.py
+++ b/dbt_invoke/internal/_utils.py
@@ -136,6 +136,8 @@ def get_project_info(ctx, project_dir=None):
     template_path = Path(project_path, 'dbt_invoke_template.yml')
     if template_path.exists():
         ctx.config['template_yml'] = parse_yaml(template_path)
+    else:
+        ctx.config['template_yml'] = None
     # Set context config key-value pairs
     ctx.config['project_path'] = project_path
     ctx.config['project_name'] = project_name

--- a/dbt_invoke/internal/_utils.py
+++ b/dbt_invoke/internal/_utils.py
@@ -132,6 +132,10 @@ def get_project_info(ctx, project_dir=None):
         Path(project_path, macro_path)
         for macro_path in project_yml.get('macro-paths', ['macros'])
     ]
+    # retrieves template information if provided
+    template_path = Path(project_path, 'dbt_invoke_template.yml')
+    if template_path.exists():
+        ctx.config['template_yml'] = parse_yaml(template_path)
     # Set context config key-value pairs
     ctx.config['project_path'] = project_path
     ctx.config['project_name'] = project_name

--- a/dbt_invoke/properties.py
+++ b/dbt_invoke/properties.py
@@ -839,7 +839,7 @@ def _structure_property_file_dict(
         )
         # If dbt_invoke_template.yml exists, adds templated properties to column 
         # when not already present
-        if template_yml and 'columns' in template_yml.get(resource_type):
+        if template_yml and 'columns' in template_yml.get(resource_type, dict()):
             _apply_template(
                 column_dict, template_yml[resource_type]['columns']
             )

--- a/dbt_invoke/properties.py
+++ b/dbt_invoke/properties.py
@@ -715,6 +715,7 @@ def _create_property_file(
         property_path,
         resource_dict,
         columns,
+        ctx.config['template_yml']
     )
     _utils.write_yaml(
         property_path,
@@ -786,7 +787,12 @@ def _get_columns(ctx, resource_location, resource_dict, **kwargs):
         return columns
 
 
-def _structure_property_file_dict(location, resource_dict, columns_list):
+def _structure_property_file_dict(
+    location,
+    resource_dict,
+    columns_list,
+    template_yml
+):
     """
     Structure a dictionary that will be used to create a property file
 
@@ -813,6 +819,12 @@ def _structure_property_file_dict(location, resource_dict, columns_list):
         property_file_dict = _get_property_header(resource_name, resource_type)
     # Get the sub-dictionaries of each existing column
     resource_type_plural = _SUPPORTED_RESOURCE_TYPES[resource_type]
+    # If dbt_invoke_template.yml exists, adds templated properties to header 
+    # when not already present
+    if template_yml and resource_type in template_yml:
+        _apply_template(
+            property_file_dict[resource_type_plural][0], template_yml[resource_type]
+        )
     existing_columns_dict = {
         item['name']: item
         for item in property_file_dict[resource_type_plural][0]['columns']
@@ -825,10 +837,31 @@ def _structure_property_file_dict(location, resource_dict, columns_list):
         column_dict = existing_columns_dict.get(
             column, _get_property_column(column)
         )
+        # If dbt_invoke_template.yml exists, adds templated properties to column 
+        # when not already present
+        if template_yml and 'columns' in template_yml.get(resource_type):
+            _apply_template(
+                column_dict, template_yml[resource_type]['columns']
+            )
         property_file_dict[resource_type_plural][0]['columns'].append(
             column_dict
         )
     return property_file_dict
+
+
+def _apply_template(property_dict, template):
+    """
+    Updates a dictionary with template's yml default properties
+    if said dictionary does not already contain the properties.
+
+    :param property_dict: the dictionary to be updated
+    :param template: a dictionary representing the templated properties
+        to be applied on property_dict
+    :return: None
+    """
+    for key in template:
+        if key not in property_dict:
+            property_dict[key] = template[key]
 
 
 def _get_property_header(resource, resource_type, properties=None):


### PR DESCRIPTION
hey, first of all, thanks for building this package, it's been a pleasure using it!

--- 

Our team recently started to use what's in the `meta` field, most notably to set the `meta.owner` property:

```
version: 2
models:
- name: dim_user
  description: >
    Some description
  meta:
    owner: '@data-team'
  columns:
  - name: user_id
    description: ''
    tests:
    - not_null
    - unique
  - name: some_col
    description: ''
  - name: some_other_col
    description: ''
```

In this case, `@data-team` is our default, which we sometimes replace with an individual owner, eg. `@david`, if the data model is very particular. This default value, we want it on every single data models that we create, and it was a little tedious to update all newly created `.yml` file with the property.

This PR adds an optional `dbt_invoke_template.yml` that will add default properties to the files updated by dbt-invoke.

What changes:

1. load the contents of `dbt_invoke_template.yml` in `_util.py`,
2. update the `_structure_property_file_dict` to apply the template's default properties.

I've also updated the `README.md` file so you can better understand how this works, and I've tested this by updating my local dbt-invoke package.

(feel free to edit anything on this; I'd love to have this functionality, so I'm saving the frustration of manually adding `meta.owner`)